### PR TITLE
Add TimesNetRange with quantile forecasting

### DIFF
--- a/exp/exp_basic.py
+++ b/exp/exp_basic.py
@@ -3,7 +3,7 @@ import torch
 from models import Autoformer, Transformer, TimesNet, Nonstationary_Transformer, DLinear, FEDformer, \
     Informer, LightTS, Reformer, ETSformer, Pyraformer, PatchTST, MICN, Crossformer, FiLM, iTransformer, \
     Koopa, TiDE, FreTS, TimeMixer, TSMixer, SegRNN, MambaSimple, TemporalFusionTransformer, SCINet, PAttn, TimeXer, \
-    WPMixer, MultiPatchFormer
+    WPMixer, MultiPatchFormer, TimesNetRange
 
 
 class Exp_Basic(object):
@@ -38,7 +38,8 @@ class Exp_Basic(object):
             'PAttn': PAttn,
             'TimeXer': TimeXer,
             'WPMixer': WPMixer,
-            'MultiPatchFormer': MultiPatchFormer
+            'MultiPatchFormer': MultiPatchFormer,
+            'TimesNetRange': TimesNetRange
         }
         if args.model == 'Mamba':
             print('Please make sure you have successfully installed mamba_ssm')

--- a/exp/exp_long_term_forecasting.py
+++ b/exp/exp_long_term_forecasting.py
@@ -35,8 +35,12 @@ class Exp_Long_Term_Forecast(Exp_Basic):
         return model_optim
 
     def _select_criterion(self):
-        criterion = nn.MSELoss()
-        return criterion
+        if self.args.loss.lower() == 'quantile':
+            quantiles = [float(q) for q in self.args.quantiles.split(',')]
+            from utils.losses import QuantileLoss
+            return QuantileLoss(quantiles)
+        else:
+            return nn.MSELoss()
  
 
     def vali(self, vali_data, vali_loader, criterion):
@@ -60,8 +64,12 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                 else:
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
                 f_dim = -1 if self.args.features == 'MS' else 0
-                outputs = outputs[:, -self.args.pred_len:, f_dim:]
-                batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
+                if outputs.dim() == 4:
+                    outputs = outputs[:, -self.args.pred_len:, f_dim:, :]
+                    batch_y = batch_y[:, -self.args.pred_len:, f_dim:].unsqueeze(-1).to(self.device)
+                else:
+                    outputs = outputs[:, -self.args.pred_len:, f_dim:]
+                    batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
 
                 pred = outputs.detach().cpu()
                 true = batch_y.detach().cpu()
@@ -117,16 +125,24 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                         outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
 
                         f_dim = -1 if self.args.features == 'MS' else 0
-                        outputs = outputs[:, -self.args.pred_len:, f_dim:]
-                        batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
+                        if outputs.dim() == 4:
+                            outputs = outputs[:, -self.args.pred_len:, f_dim:, :]
+                            batch_y = batch_y[:, -self.args.pred_len:, f_dim:].unsqueeze(-1).to(self.device)
+                        else:
+                            outputs = outputs[:, -self.args.pred_len:, f_dim:]
+                            batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
                         loss = criterion(outputs, batch_y)
                         train_loss.append(loss.item())
                 else:
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
 
                     f_dim = -1 if self.args.features == 'MS' else 0
-                    outputs = outputs[:, -self.args.pred_len:, f_dim:]
-                    batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
+                    if outputs.dim() == 4:
+                        outputs = outputs[:, -self.args.pred_len:, f_dim:, :]
+                        batch_y = batch_y[:, -self.args.pred_len:, f_dim:].unsqueeze(-1).to(self.device)
+                    else:
+                        outputs = outputs[:, -self.args.pred_len:, f_dim:]
+                        batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
                     loss = criterion(outputs, batch_y)
                     train_loss.append(loss.item())
 
@@ -197,23 +213,30 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
 
                 f_dim = -1 if self.args.features == 'MS' else 0
-                outputs = outputs[:, -self.args.pred_len:, :]
-                batch_y = batch_y[:, -self.args.pred_len:, :].to(self.device)
-                outputs = outputs.detach().cpu().numpy()
+                if outputs.dim() == 4:
+                    outputs = outputs[:, -self.args.pred_len:, :, :]
+                    batch_y = batch_y[:, -self.args.pred_len:, :].to(self.device)
+                    pred_numpy = outputs[..., len(self.model.quantiles)//2].detach().cpu().numpy()
+                    all_outputs = outputs.detach().cpu().numpy()
+                else:
+                    outputs = outputs[:, -self.args.pred_len:, :]
+                    batch_y = batch_y[:, -self.args.pred_len:, :].to(self.device)
+                    pred_numpy = outputs.detach().cpu().numpy()
+                    all_outputs = pred_numpy
                 batch_y = batch_y.detach().cpu().numpy()
                 if test_data.scale and self.args.inverse:
                     shape = batch_y.shape
-                    if outputs.shape[-1] != batch_y.shape[-1]:
-                        outputs = np.tile(outputs, [1, 1, int(batch_y.shape[-1] / outputs.shape[-1])])
-                    outputs = test_data.inverse_transform(outputs.reshape(shape[0] * shape[1], -1)).reshape(shape)
+                    if pred_numpy.shape[-1] != batch_y.shape[-1]:
+                        pred_numpy = np.tile(pred_numpy, [1, 1, int(batch_y.shape[-1] / pred_numpy.shape[-1])])
+                    pred_numpy = test_data.inverse_transform(pred_numpy.reshape(shape[0] * shape[1], -1)).reshape(shape)
                     batch_y = test_data.inverse_transform(batch_y.reshape(shape[0] * shape[1], -1)).reshape(shape)
 
-                outputs = outputs[:, :, f_dim:]
+                pred_numpy = pred_numpy[:, :, f_dim:]
                 batch_y = batch_y[:, :, f_dim:]
 
-                pred = outputs
+                pred = pred_numpy
                 true = batch_y
-
+                
                 preds.append(pred)
                 trues.append(true)
                 if i % 20 == 0:

--- a/exp/exp_short_term_forecasting.py
+++ b/exp/exp_short_term_forecasting.py
@@ -41,7 +41,7 @@ class Exp_Short_Term_Forecast(Exp_Basic):
         return model_optim
 
     def _select_criterion(self, loss_name='MSE'):
-        if loss_name == 'MSE':
+        if loss_name.upper() == 'MSE':
             return nn.MSELoss()
         elif loss_name == 'MAPE':
             return mape_loss()
@@ -49,6 +49,10 @@ class Exp_Short_Term_Forecast(Exp_Basic):
             return mase_loss()
         elif loss_name == 'SMAPE':
             return smape_loss()
+        elif loss_name.lower() == 'quantile':
+            quantiles = [float(q) for q in self.args.quantiles.split(',')]
+            from utils.losses import QuantileLoss
+            return QuantileLoss(quantiles)
 
     def train(self, setting):
         train_data, train_loader = self._get_data(flag='train')
@@ -88,8 +92,12 @@ class Exp_Short_Term_Forecast(Exp_Basic):
                 outputs = self.model(batch_x, None, dec_inp, None)
 
                 f_dim = -1 if self.args.features == 'MS' else 0
-                outputs = outputs[:, -self.args.pred_len:, f_dim:]
-                batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
+                if outputs.dim() == 4:
+                    outputs = outputs[:, -self.args.pred_len:, f_dim:, :]
+                    batch_y = batch_y[:, -self.args.pred_len:, f_dim:].unsqueeze(-1).to(self.device)
+                else:
+                    outputs = outputs[:, -self.args.pred_len:, f_dim:]
+                    batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
 
                 batch_y_mark = batch_y_mark[:, -self.args.pred_len:, f_dim:].to(self.device)
                 loss_value = criterion(batch_x, self.args.frequency_map, outputs, batch_y, batch_y_mark)
@@ -147,12 +155,17 @@ class Exp_Short_Term_Forecast(Exp_Basic):
                                                                       dec_inp[id_list[i]:id_list[i + 1]],
                                                                       None).detach().cpu()
             f_dim = -1 if self.args.features == 'MS' else 0
-            outputs = outputs[:, -self.args.pred_len:, f_dim:]
+            if outputs.dim() == 4:
+                outputs = outputs[:, -self.args.pred_len:, f_dim:, :]
+                y_tensor = torch.from_numpy(np.array(y)).unsqueeze(-1)
+            else:
+                outputs = outputs[:, -self.args.pred_len:, f_dim:]
+                y_tensor = torch.from_numpy(np.array(y))
             pred = outputs
-            true = torch.from_numpy(np.array(y))
+            true = y_tensor
             batch_y_mark = torch.ones(true.shape)
 
-            loss = criterion(x.detach().cpu()[:, :, 0], self.args.frequency_map, pred[:, :, 0], true, batch_y_mark)
+            loss = criterion(pred, true)
 
         self.model.train()
         return loss
@@ -190,10 +203,12 @@ class Exp_Short_Term_Forecast(Exp_Basic):
                     print(id_list[i])
 
             f_dim = -1 if self.args.features == 'MS' else 0
-            outputs = outputs[:, -self.args.pred_len:, f_dim:]
-            outputs = outputs.detach().cpu().numpy()
-
-            preds = outputs
+            if outputs.dim() == 4:
+                outputs = outputs[:, -self.args.pred_len:, f_dim:, :]
+                preds = outputs[..., len(self.args.quantiles.split(','))//2].detach().cpu().numpy()
+            else:
+                outputs = outputs[:, -self.args.pred_len:, f_dim:]
+                preds = outputs.detach().cpu().numpy()
             trues = y
             x = x.detach().cpu().numpy()
 

--- a/models/TimesNetRange.py
+++ b/models/TimesNetRange.py
@@ -1,0 +1,101 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from layers.Embed import DataEmbedding
+from layers.Conv_Blocks import Inception_Block_V1
+
+
+def FFT_for_Period(x, k=2):
+    xf = torch.fft.rfft(x, dim=1)
+    frequency_list = abs(xf).mean(0).mean(-1)
+    frequency_list[0] = 0
+    _, top_list = torch.topk(frequency_list, k)
+    top_list = top_list.detach().cpu().numpy()
+    period = x.shape[1] // top_list
+    return period, abs(xf).mean(-1)[:, top_list]
+
+
+class TimesBlock(nn.Module):
+    def __init__(self, configs):
+        super().__init__()
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.k = configs.top_k
+        self.conv = nn.Sequential(
+            Inception_Block_V1(configs.d_model, configs.d_ff,
+                               num_kernels=configs.num_kernels),
+            nn.GELU(),
+            Inception_Block_V1(configs.d_ff, configs.d_model,
+                               num_kernels=configs.num_kernels)
+        )
+
+    def forward(self, x):
+        B, T, N = x.size()
+        period_list, period_weight = FFT_for_Period(x, self.k)
+        res = []
+        for i in range(self.k):
+            period = period_list[i]
+            if (self.seq_len + self.pred_len) % period != 0:
+                length = ((self.seq_len + self.pred_len) // period + 1) * period
+                padding = torch.zeros([x.shape[0], length - (self.seq_len + self.pred_len), x.shape[2]], device=x.device)
+                out = torch.cat([x, padding], dim=1)
+            else:
+                length = self.seq_len + self.pred_len
+                out = x
+            out = out.reshape(B, length // period, period, N).permute(0, 3, 1, 2)
+            out = self.conv(out)
+            out = out.permute(0, 2, 3, 1).reshape(B, -1, N)
+            res.append(out[:, :(self.seq_len + self.pred_len), :])
+        res = torch.stack(res, dim=-1)
+        period_weight = F.softmax(period_weight, dim=1)
+        period_weight = period_weight.unsqueeze(1).unsqueeze(1).repeat(1, T, N, 1)
+        res = torch.sum(res * period_weight, -1)
+        res = res + x
+        return res
+
+
+class Model(nn.Module):
+    """TimesNet for prediction interval forecasting"""
+
+    def __init__(self, configs):
+        super().__init__()
+        self.configs = configs
+        self.task_name = configs.task_name
+        self.seq_len = configs.seq_len
+        self.label_len = configs.label_len
+        self.pred_len = configs.pred_len
+        self.quantiles = getattr(configs, "quantiles", [0.1, 0.5, 0.9])
+        self.model = nn.ModuleList([TimesBlock(configs) for _ in range(configs.e_layers)])
+        self.enc_embedding = DataEmbedding(configs.enc_in, configs.d_model, configs.embed, configs.freq,
+                                           configs.dropout)
+        self.layer = configs.e_layers
+        self.layer_norm = nn.LayerNorm(configs.d_model)
+        self.predict_linear = nn.Linear(self.seq_len, self.pred_len + self.seq_len)
+        self.projections = nn.ModuleList([
+            nn.Linear(configs.d_model, configs.c_out, bias=True) for _ in self.quantiles
+        ])
+
+    def forecast(self, x_enc, x_mark_enc):
+        means = x_enc.mean(1, keepdim=True).detach()
+        x_enc = x_enc - means
+        stdev = torch.sqrt(torch.var(x_enc, dim=1, keepdim=True, unbiased=False) + 1e-5)
+        x_enc = x_enc / stdev
+        enc_out = self.enc_embedding(x_enc, x_mark_enc)
+        enc_out = self.predict_linear(enc_out.permute(0, 2, 1)).permute(0, 2, 1)
+        for i in range(self.layer):
+            enc_out = self.layer_norm(self.model[i](enc_out))
+        outs = []
+        for proj in self.projections:
+            dec_out = proj(enc_out)
+            dec_out = dec_out * stdev[:, 0, :].unsqueeze(1).repeat(1, self.pred_len + self.seq_len, 1)
+            dec_out = dec_out + means[:, 0, :].unsqueeze(1).repeat(1, self.pred_len + self.seq_len, 1)
+            outs.append(dec_out.unsqueeze(-1))
+        dec_out = torch.cat(outs, dim=-1)
+        return dec_out
+
+    def forward(self, x_enc, x_mark_enc, x_dec=None, x_mark_dec=None, mask=None):
+        if self.task_name in ['long_term_forecast', 'short_term_forecast']:
+            out = self.forecast(x_enc, x_mark_enc)
+            return out[:, -self.pred_len:, :, :]
+        else:
+            raise NotImplementedError("TimesNetRange only supports forecasting tasks")

--- a/run.py
+++ b/run.py
@@ -94,6 +94,8 @@ if __name__ == '__main__':
     parser.add_argument('--learning_rate', type=float, default=0.0001, help='optimizer learning rate')
     parser.add_argument('--des', type=str, default='test', help='exp description')
     parser.add_argument('--loss', type=str, default='MSE', help='loss function')
+    parser.add_argument('--quantiles', type=str, default='0.1,0.5,0.9',
+                        help='quantiles for QuantileLoss, separated by comma')
     parser.add_argument('--lradj', type=str, default='type1', help='adjust learning rate')
     parser.add_argument('--use_amp', action='store_true', help='use automatic mixed precision training', default=False)
 

--- a/utils/losses.py
+++ b/utils/losses.py
@@ -87,3 +87,19 @@ class mase_loss(nn.Module):
         masep = t.mean(t.abs(insample[:, freq:] - insample[:, :-freq]), dim=1)
         masked_masep_inv = divide_no_nan(mask, masep[:, None])
         return t.mean(t.abs(target - forecast) * masked_masep_inv)
+
+class QuantileLoss(nn.Module):
+    """Pinball loss for multiple quantile predictions."""
+
+    def __init__(self, quantiles):
+        super().__init__()
+        self.quantiles = quantiles
+
+    def forward(self, preds: t.Tensor, target: t.Tensor) -> t.Tensor:
+        # preds: [B, L, D, Q], target: [B, L, D]
+        losses = []
+        for i, q in enumerate(self.quantiles):
+            errors = target - preds[..., i]
+            losses.append(t.max((q - 1) * errors, q * errors))
+        loss = t.mean(t.stack(losses, dim=-1))
+        return loss


### PR DESCRIPTION
## Summary
- introduce `TimesNetRange` model for interval forecasting
- add `QuantileLoss` for pinball regression
- support quantile loss and predictions in experiment runners
- register new model
- allow `--quantiles` option

## Testing
- `python -m py_compile models/TimesNetRange.py utils/losses.py exp/exp_long_term_forecasting.py exp/exp_short_term_forecasting.py exp/exp_basic.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_686f5758646c83238c7c4aa5da663f1d