### PR TITLE
Add TimesNetRange model for fast interval forecasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ bash ./scripts/classification/TimesNet.sh
 - Include the newly added model in the `Exp_Basic.model_dict` of  `./exp/exp_basic.py`.
 - Create the corresponding scripts under the folder `./scripts`.
 
+To train with your own folder of CSV files, use the `csvfolder` dataset
+via `Dataset_CSVFolder`. Your files must share the same columns and contain a
+`timestamp` column. Select the desired state with `--state` and provide a
+boolean expression with `--state_condition` to mark running rows. For example,
+`--state running --state_condition "rpm >= 10 & speed > 0"` keeps only rows
+matching that expression.
+
+Example command:
+
+```
+python run.py --task_name long_term_forecast \
+  --is_training 1 --model TimesNetRange --data csvfolder \
+  --root_path /path/to/csv_folder --target value --seq_len 96 \
+  --label_len 48 --pred_len 96 --state running \
+  --state_condition "rpm >= 10"
+```
+
 Note: 
 
 (1) About classification: Since we include all five tasks in a unified code base, the accuracy of each subtask may fluctuate but the average performance can be reproduced (even a bit better). We have provided the reproduced checkpoints [here](https://github.com/thuml/Time-Series-Library/issues/494).

--- a/data_provider/data_factory.py
+++ b/data_provider/data_factory.py
@@ -1,4 +1,4 @@
-from data_provider.data_loader import Dataset_ETT_hour, Dataset_ETT_minute, Dataset_Custom, Dataset_M4, PSMSegLoader, \
+from data_provider.data_loader import Dataset_ETT_hour, Dataset_ETT_minute, Dataset_Custom, Dataset_CSVFolder, Dataset_M4, PSMSegLoader, \
     MSLSegLoader, SMAPSegLoader, SMDSegLoader, SWATSegLoader, UEAloader
 from data_provider.uea import collate_fn
 from torch.utils.data import DataLoader
@@ -9,6 +9,7 @@ data_dict = {
     'ETTm1': Dataset_ETT_minute,
     'ETTm2': Dataset_ETT_minute,
     'custom': Dataset_Custom,
+    'csvfolder': Dataset_CSVFolder,
     'm4': Dataset_M4,
     'PSM': PSMSegLoader,
     'MSL': MSLSegLoader,
@@ -64,6 +65,10 @@ def data_provider(args, flag):
     else:
         if args.data == 'm4':
             drop_last = False
+        extra_kwargs = {}
+        if args.data == 'csvfolder':
+            extra_kwargs.update({'state': args.state,
+                                 'state_condition': args.state_condition})
         data_set = Data(
             args = args,
             root_path=args.root_path,
@@ -74,7 +79,8 @@ def data_provider(args, flag):
             target=args.target,
             timeenc=timeenc,
             freq=freq,
-            seasonal_patterns=args.seasonal_patterns
+            seasonal_patterns=args.seasonal_patterns,
+            **extra_kwargs
         )
         print(flag, len(data_set))
         data_loader = DataLoader(

--- a/data_provider/data_loader.py
+++ b/data_provider/data_loader.py
@@ -307,6 +307,155 @@ class Dataset_Custom(Dataset):
         return self.scaler.inverse_transform(data)
 
 
+class Dataset_CSVFolder(Dataset):
+    """Load a folder of csv files with a timestamp column.
+
+    Parameters
+    ----------
+    state : {'all', 'running', 'standby'}
+        Which rows to keep. Rows are labelled by evaluating ``state_condition``
+        if provided, otherwise ``state_column`` or ``speed_column``.
+    state_condition : str, optional
+        Boolean expression evaluated on each file to identify running rows,
+        e.g. ``"rpm >= 10 & speed > 0"``.
+    """
+
+    def __init__(self, args, root_path, flag='train', size=None,
+                 features='S', target='value', scale=True, timeenc=0, freq='h',
+                 state='all', state_column='state', speed_column='speed',
+                 speed_threshold=0.1, state_condition=None):
+        self.args = args
+        if size is None:
+            self.seq_len = 96
+            self.label_len = 48
+            self.pred_len = 96
+        else:
+            self.seq_len = size[0]
+            self.label_len = size[1]
+            self.pred_len = size[2]
+
+        assert flag in ['train', 'test', 'val']
+        type_map = {'train': 0, 'val': 1, 'test': 2}
+        self.set_type = type_map[flag]
+
+        self.features = features
+        self.target = target
+        self.scale = scale
+        self.timeenc = timeenc
+        self.freq = freq
+
+        self.root_path = root_path
+        self.state = state
+        self.state_column = state_column
+        self.speed_column = speed_column
+        self.speed_threshold = speed_threshold
+        self.state_condition = state_condition
+
+        self.__read_data__()
+
+    def _load_folder(self):
+        files = sorted(glob.glob(os.path.join(self.root_path, '*.csv')))
+        if not files:
+            raise FileNotFoundError(f'No csv files found in {self.root_path}')
+        frames = []
+        for f in files:
+            df = pd.read_csv(f)
+            if 'timestamp' not in df.columns:
+                raise ValueError('timestamp column required in %s' % f)
+            df['timestamp'] = pd.to_datetime(df['timestamp'])
+            if self.state != 'all':
+                if self.state_condition is not None:
+                    mask = df.eval(self.state_condition)
+                    if self.state == 'running':
+                        df = df[mask]
+                    else:
+                        df = df[~mask]
+                elif self.state_column in df.columns:
+                    if self.state == 'running':
+                        df = df[df[self.state_column] == 1]
+                    else:
+                        df = df[df[self.state_column] == 0]
+                elif self.speed_column in df.columns:
+                    if self.state == 'running':
+                        df = df[df[self.speed_column] > self.speed_threshold]
+                    else:
+                        df = df[df[self.speed_column] <= self.speed_threshold]
+            frames.append(df)
+        data = pd.concat(frames).sort_values('timestamp').reset_index(drop=True)
+        data = data.set_index('timestamp').resample(self.freq).mean().interpolate()
+        data = data.reset_index()
+        return data
+
+    def __read_data__(self):
+        self.scaler = StandardScaler()
+        df_raw = self._load_folder()
+
+        cols = list(df_raw.columns)
+        cols.remove(self.target)
+        cols.remove('timestamp')
+        df_raw = df_raw[['timestamp'] + cols + [self.target]]
+
+        num_train = int(len(df_raw) * 0.7)
+        num_test = int(len(df_raw) * 0.2)
+        num_vali = len(df_raw) - num_train - num_test
+        border1s = [0, num_train - self.seq_len, len(df_raw) - num_test - self.seq_len]
+        border2s = [num_train, num_train + num_vali, len(df_raw)]
+        border1 = border1s[self.set_type]
+        border2 = border2s[self.set_type]
+
+        if self.features in ['M', 'MS']:
+            cols_data = df_raw.columns[1:]
+            df_data = df_raw[cols_data]
+        else:
+            df_data = df_raw[[self.target]]
+
+        if self.scale:
+            train_data = df_data[border1s[0]:border2s[0]]
+            self.scaler.fit(train_data.values)
+            data = self.scaler.transform(df_data.values)
+        else:
+            data = df_data.values
+
+        df_stamp = df_raw[['timestamp']][border1:border2]
+        df_stamp['timestamp'] = pd.to_datetime(df_stamp.timestamp)
+        if self.timeenc == 0:
+            df_stamp['month'] = df_stamp.timestamp.apply(lambda row: row.month, 1)
+            df_stamp['day'] = df_stamp.timestamp.apply(lambda row: row.day, 1)
+            df_stamp['weekday'] = df_stamp.timestamp.apply(lambda row: row.weekday(), 1)
+            df_stamp['hour'] = df_stamp.timestamp.apply(lambda row: row.hour, 1)
+            data_stamp = df_stamp.drop(['timestamp'], 1).values
+        else:
+            data_stamp = time_features(pd.to_datetime(df_stamp['timestamp'].values), freq=self.freq)
+            data_stamp = data_stamp.transpose(1, 0)
+
+        self.data_x = data[border1:border2]
+        self.data_y = data[border1:border2]
+
+        if self.set_type == 0 and self.args.augmentation_ratio > 0:
+            self.data_x, self.data_y, _ = run_augmentation_single(self.data_x, self.data_y, self.args)
+
+        self.data_stamp = data_stamp
+
+    def __getitem__(self, index):
+        s_begin = index
+        s_end = s_begin + self.seq_len
+        r_begin = s_end - self.label_len
+        r_end = r_begin + self.label_len + self.pred_len
+
+        seq_x = self.data_x[s_begin:s_end]
+        seq_y = self.data_y[r_begin:r_end]
+        seq_x_mark = self.data_stamp[s_begin:s_end]
+        seq_y_mark = self.data_stamp[r_begin:r_end]
+
+        return seq_x, seq_y, seq_x_mark, seq_y_mark
+
+    def __len__(self):
+        return len(self.data_x) - self.seq_len - self.pred_len + 1
+
+    def inverse_transform(self, data):
+        return self.scaler.inverse_transform(data)
+
+
 class Dataset_M4(Dataset):
     def __init__(self, args, root_path, flag='pred', size=None,
                  features='S', data_path='ETTh1.csv',

--- a/exp/exp_basic.py
+++ b/exp/exp_basic.py
@@ -3,7 +3,7 @@ import torch
 from models import Autoformer, Transformer, TimesNet, Nonstationary_Transformer, DLinear, FEDformer, \
     Informer, LightTS, Reformer, ETSformer, Pyraformer, PatchTST, MICN, Crossformer, FiLM, iTransformer, \
     Koopa, TiDE, FreTS, TimeMixer, TSMixer, SegRNN, MambaSimple, TemporalFusionTransformer, SCINet, PAttn, TimeXer, \
-    WPMixer, MultiPatchFormer
+    WPMixer, MultiPatchFormer, TimesNetRange
 
 
 class Exp_Basic(object):
@@ -38,7 +38,8 @@ class Exp_Basic(object):
             'PAttn': PAttn,
             'TimeXer': TimeXer,
             'WPMixer': WPMixer,
-            'MultiPatchFormer': MultiPatchFormer
+            'MultiPatchFormer': MultiPatchFormer,
+            'TimesNetRange': TimesNetRange
         }
         if args.model == 'Mamba':
             print('Please make sure you have successfully installed mamba_ssm')

--- a/exp/exp_long_term_forecasting.py
+++ b/exp/exp_long_term_forecasting.py
@@ -59,6 +59,8 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                         outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
                 else:
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                if isinstance(outputs, tuple):
+                    outputs = outputs[0]
                 f_dim = -1 if self.args.features == 'MS' else 0
                 outputs = outputs[:, -self.args.pred_len:, f_dim:]
                 batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
@@ -115,20 +117,16 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                 if self.args.use_amp:
                     with torch.cuda.amp.autocast():
                         outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
-
-                        f_dim = -1 if self.args.features == 'MS' else 0
-                        outputs = outputs[:, -self.args.pred_len:, f_dim:]
-                        batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                        loss = criterion(outputs, batch_y)
-                        train_loss.append(loss.item())
                 else:
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                if isinstance(outputs, tuple):
+                    outputs = outputs[0]
 
-                    f_dim = -1 if self.args.features == 'MS' else 0
-                    outputs = outputs[:, -self.args.pred_len:, f_dim:]
-                    batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                    loss = criterion(outputs, batch_y)
-                    train_loss.append(loss.item())
+                f_dim = -1 if self.args.features == 'MS' else 0
+                outputs = outputs[:, -self.args.pred_len:, f_dim:]
+                batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
+                loss = criterion(outputs, batch_y)
+                train_loss.append(loss.item())
 
                 if (i + 1) % 100 == 0:
                     print("\titers: {0}, epoch: {1} | loss: {2:.7f}".format(i + 1, epoch + 1, loss.item()))
@@ -195,6 +193,8 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                         outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
                 else:
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                if isinstance(outputs, tuple):
+                    outputs = outputs[0]
 
                 f_dim = -1 if self.args.features == 'MS' else 0
                 outputs = outputs[:, -self.args.pred_len:, :]

--- a/models/TimesNetRange.py
+++ b/models/TimesNetRange.py
@@ -1,0 +1,109 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from layers.Embed import DataEmbedding
+from layers.Autoformer_EncDec import series_decomp
+from layers.Conv_Blocks import Inception_Block_V2
+
+
+def FFT_for_Period(x, k=2):
+    xf = torch.fft.rfft(x, dim=1)
+    frequency_list = abs(xf).mean(0).mean(-1)
+    frequency_list[0] = 0
+    _, top_list = torch.topk(frequency_list, k)
+    top_list = top_list.detach().cpu().numpy()
+    period = x.shape[1] // top_list
+    return period, abs(xf).mean(-1)[:, top_list]
+
+
+class DLinearBlock(nn.Module):
+    """Lightweight DLinear block for baseline forecasting."""
+    def __init__(self, configs):
+        super().__init__()
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.decomp = series_decomp(configs.moving_avg)
+        self.linear_season = nn.Linear(self.seq_len, self.pred_len)
+        self.linear_trend = nn.Linear(self.seq_len, self.pred_len)
+        self.linear_season.weight = nn.Parameter((1 / self.seq_len) * torch.ones([self.pred_len, self.seq_len]))
+        self.linear_trend.weight = nn.Parameter((1 / self.seq_len) * torch.ones([self.pred_len, self.seq_len]))
+
+    def forward(self, x):
+        season, trend = self.decomp(x)
+        season_out = self.linear_season(season.permute(0, 2, 1))
+        trend_out = self.linear_trend(trend.permute(0, 2, 1))
+        out = season_out + trend_out
+        return out.permute(0, 2, 1)
+
+
+class TimesBlockLite(nn.Module):
+    """A lightweight version of TimesBlock for fast inference."""
+    def __init__(self, configs):
+        super().__init__()
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.k = max(1, configs.top_k // 2)
+        kernel_num = max(2, configs.num_kernels // 2)
+        self.conv = nn.Sequential(
+            Inception_Block_V2(configs.d_model, configs.d_ff, num_kernels=kernel_num),
+            nn.GELU(),
+            Inception_Block_V2(configs.d_ff, configs.d_model, num_kernels=kernel_num)
+        )
+
+    def forward(self, x):
+        B, T, N = x.size()
+        period_list, period_weight = FFT_for_Period(x, self.k)
+        res = []
+        for i in range(self.k):
+            period = period_list[i]
+            if (self.seq_len + self.pred_len) % period != 0:
+                length = ((self.seq_len + self.pred_len) // period + 1) * period
+                padding = torch.zeros([x.shape[0], length - (self.seq_len + self.pred_len), x.shape[2]], device=x.device)
+                out = torch.cat([x, padding], dim=1)
+            else:
+                length = self.seq_len + self.pred_len
+                out = x
+            out = out.reshape(B, length // period, period, N).permute(0, 3, 1, 2).contiguous()
+            out = self.conv(out)
+            out = out.permute(0, 2, 3, 1).reshape(B, -1, N)
+            res.append(out[:, :self.seq_len + self.pred_len, :])
+        res = torch.stack(res, dim=-1)
+        period_weight = F.softmax(period_weight, dim=1)
+        period_weight = period_weight.unsqueeze(1).unsqueeze(1).repeat(1, T, N, 1)
+        res = torch.sum(res * period_weight, -1)
+        return res + x
+
+
+class Model(nn.Module):
+    """TimesNet variant with interval prediction."""
+    def __init__(self, configs):
+        super().__init__()
+        self.configs = configs
+        self.task_name = configs.task_name
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.interval_mult = getattr(configs, 'interval_mult', 2.0)
+
+        self.baseline = DLinearBlock(configs)
+        self.enc_embedding = DataEmbedding(configs.enc_in, configs.d_model, configs.embed, configs.freq, configs.dropout)
+        self.layers = nn.ModuleList([TimesBlockLite(configs) for _ in range(configs.e_layers)])
+        self.layer_norm = nn.LayerNorm(configs.d_model)
+        self.mean_projection = nn.Linear(configs.d_model, configs.c_out, bias=True)
+        self.var_projection = nn.Linear(configs.d_model, configs.c_out, bias=True)
+
+    def forward(self, x_enc, x_mark_enc, x_dec=None, x_mark_dec=None):
+        baseline = self.baseline(x_enc)
+        enc_out = self.enc_embedding(x_enc, x_mark_enc)
+        for block in self.layers:
+            enc_out = self.layer_norm(block(enc_out))
+        mean_residual = self.mean_projection(enc_out)
+        log_var = self.var_projection(enc_out)
+        mean = baseline + mean_residual
+        std = torch.sqrt(F.softplus(log_var) + 1e-6)
+        lower = mean - self.interval_mult * std
+        upper = mean + self.interval_mult * std
+
+        if self.task_name in ['long_term_forecast', 'short_term_forecast']:
+            return mean[:, -self.pred_len:, :], lower[:, -self.pred_len:, :], upper[:, -self.pred_len:, :]
+        else:
+            return mean[:, -self.pred_len:, :]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+from .TimesNetRange import Model as TimesNetRange

--- a/run.py
+++ b/run.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     parser.add_argument('--is_training', type=int, required=True, default=1, help='status')
     parser.add_argument('--model_id', type=str, required=True, default='test', help='model id')
     parser.add_argument('--model', type=str, required=True, default='Autoformer',
-                        help='model name, options: [Autoformer, Transformer, TimesNet]')
+                        help='model name, options: [Autoformer, Transformer, TimesNet, TimesNetRange]')
 
     # data loader
     parser.add_argument('--data', type=str, required=True, default='ETTh1', help='dataset type')

--- a/run.py
+++ b/run.py
@@ -36,6 +36,10 @@ if __name__ == '__main__':
     parser.add_argument('--target', type=str, default='OT', help='target feature in S or MS task')
     parser.add_argument('--freq', type=str, default='h',
                         help='freq for time features encoding, options:[s:secondly, t:minutely, h:hourly, d:daily, b:business days, w:weekly, m:monthly], you can also use more detailed freq like 15min or 3h')
+    parser.add_argument('--state', type=str, default='all', choices=['all', 'running', 'standby'],
+                        help='working state selection for csvfolder dataset')
+    parser.add_argument('--state_condition', type=str, default=None,
+                        help='expression to determine running state from columns')
     parser.add_argument('--checkpoints', type=str, default='./checkpoints/', help='location of model checkpoints')
 
     # forecasting task


### PR DESCRIPTION
## Summary
- implement `TimesNetRange` model using lighter `TimesBlock` and DLinear baseline
- allow interval predictions by returning mean, lower and upper bounds
- expose the new model in the experiment framework and CLI
- update training/validation/test loops to handle tuple outputs

## Testing
- `python -m py_compile models/TimesNetRange.py`
- `python -m py_compile exp/exp_basic.py exp/exp_long_term_forecasting.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_6878a9bd87508323b33a0228bb29821d