### PR TITLE
Add TimesNetRange_Hybrid model with example scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ python run.py --task_name long_term_forecast \
   --state_condition "rpm >= 10"
 ```
 
+You can also use the hybrid variant `TimesNetRange_Hybrid`, which adds a small
+GRU module to accelerate interval prediction:
+
+```
+python run.py --task_name long_term_forecast \
+  --is_training 1 --model TimesNetRange_Hybrid --data sqlitefolder \
+  --root_path /path/to/db_folder --table_name signals --target value \
+  --seq_len 96 --label_len 48 --pred_len 96
+```
+
 Note: 
 
 (1) About classification: Since we include all five tasks in a unified code base, the accuracy of each subtask may fluctuate but the average performance can be reproduced (even a bit better). We have provided the reproduced checkpoints [here](https://github.com/thuml/Time-Series-Library/issues/494).

--- a/models/TimesNetRange_Hybrid.py
+++ b/models/TimesNetRange_Hybrid.py
@@ -1,0 +1,104 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from layers.Embed import DataEmbedding
+from layers.Autoformer_EncDec import series_decomp
+from layers.Conv_Blocks import Inception_Block_V2
+
+class DLinearBlock(nn.Module):
+    """Lightweight DLinear block for baseline forecasting."""
+    def __init__(self, configs):
+        super().__init__()
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.decomp = series_decomp(configs.moving_avg)
+        self.linear_season = nn.Linear(self.seq_len, self.pred_len)
+        self.linear_trend = nn.Linear(self.seq_len, self.pred_len)
+        self.linear_season.weight = nn.Parameter((1 / self.seq_len) * torch.ones([self.pred_len, self.seq_len]))
+        self.linear_trend.weight = nn.Parameter((1 / self.seq_len) * torch.ones([self.pred_len, self.seq_len]))
+
+    def forward(self, x):
+        season, trend = self.decomp(x)
+        season_out = self.linear_season(season.permute(0, 2, 1))
+        trend_out = self.linear_trend(trend.permute(0, 2, 1))
+        out = season_out + trend_out
+        return out.permute(0, 2, 1)
+
+class TimesBlockLite(nn.Module):
+    """A lightweight version of TimesBlock for fast inference."""
+    def __init__(self, configs):
+        super().__init__()
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.k = max(1, configs.top_k // 2)
+        kernel_num = max(2, configs.num_kernels // 2)
+        self.conv = nn.Sequential(
+            Inception_Block_V2(configs.d_model, configs.d_ff, num_kernels=kernel_num),
+            nn.GELU(),
+            Inception_Block_V2(configs.d_ff, configs.d_model, num_kernels=kernel_num)
+        )
+
+    def forward(self, x):
+        B, T, N = x.size()
+        xf = torch.fft.rfft(x, dim=1)
+        frequency_list = abs(xf).mean(0).mean(-1)
+        frequency_list[0] = 0
+        _, top_list = torch.topk(frequency_list, self.k)
+        top_list = top_list.detach().cpu().numpy()
+        period_list = x.shape[1] // top_list
+        period_weight = abs(xf).mean(-1)[:, top_list]
+        res = []
+        for i in range(self.k):
+            period = period_list[i]
+            if (self.seq_len + self.pred_len) % period != 0:
+                length = ((self.seq_len + self.pred_len) // period + 1) * period
+                padding = torch.zeros([x.shape[0], length - (self.seq_len + self.pred_len), x.shape[2]], device=x.device)
+                out = torch.cat([x, padding], dim=1)
+            else:
+                length = self.seq_len + self.pred_len
+                out = x
+            out = out.reshape(B, length // period, period, N).permute(0, 3, 1, 2).contiguous()
+            out = self.conv(out)
+            out = out.permute(0, 2, 3, 1).reshape(B, -1, N)
+            res.append(out[:, :self.seq_len + self.pred_len, :])
+        res = torch.stack(res, dim=-1)
+        period_weight = F.softmax(period_weight, dim=1)
+        period_weight = period_weight.unsqueeze(1).unsqueeze(1).repeat(1, T, N, 1)
+        res = torch.sum(res * period_weight, -1)
+        return res + x
+
+class Model(nn.Module):
+    """Hybrid TimesNetRange model with a GRU for fast uncertainty estimation."""
+    def __init__(self, configs):
+        super().__init__()
+        self.configs = configs
+        self.task_name = configs.task_name
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.interval_mult = getattr(configs, 'interval_mult', 2.0)
+
+        self.baseline = DLinearBlock(configs)
+        self.gru = nn.GRU(input_size=configs.enc_in, hidden_size=configs.d_model, batch_first=True)
+        self.enc_embedding = DataEmbedding(configs.enc_in, configs.d_model, configs.embed, configs.freq, configs.dropout)
+        self.layers = nn.ModuleList([TimesBlockLite(configs) for _ in range(configs.e_layers)])
+        self.layer_norm = nn.LayerNorm(configs.d_model)
+        self.mean_projection = nn.Linear(configs.d_model, configs.c_out, bias=True)
+        self.var_projection = nn.Linear(configs.d_model, configs.c_out, bias=True)
+
+    def forward(self, x_enc, x_mark_enc, x_dec=None, x_mark_dec=None):
+        baseline = self.baseline(x_enc)
+        gru_out, _ = self.gru(x_enc)
+        enc_out = self.enc_embedding(x_enc, x_mark_enc) + gru_out
+        for block in self.layers:
+            enc_out = self.layer_norm(block(enc_out))
+        mean_residual = self.mean_projection(enc_out)
+        log_var = self.var_projection(enc_out)
+        mean = baseline + mean_residual
+        std = torch.sqrt(F.softplus(log_var) + 1e-6)
+        lower = mean - self.interval_mult * std
+        upper = mean + self.interval_mult * std
+
+        if self.task_name in ['long_term_forecast', 'short_term_forecast']:
+            return mean[:, -self.pred_len:, :], lower[:, -self.pred_len:, :], upper[:, -self.pred_len:, :]
+        else:
+            return mean[:, -self.pred_len:, :]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,2 @@
 from .TimesNetRange import Model as TimesNetRange
+from .TimesNetRange_Hybrid import Model as TimesNetRange_Hybrid

--- a/scripts/long_term_forecast/TimesNetRange_Hybrid_csv_vs_db.sh
+++ b/scripts/long_term_forecast/TimesNetRange_Hybrid_csv_vs_db.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Example comparison script for TimesNetRange_Hybrid using CSVFolder and SQLiteFolder loaders
+
+export CUDA_VISIBLE_DEVICES=0
+model_name=TimesNetRange_Hybrid
+
+# ---------- CSVFolder ----------
+python -u run.py \
+  --task_name long_term_forecast \
+  --is_training 0 \
+  --data csvfolder \
+  --root_path /path/to/csv/folder/ \
+  --state all \
+  --model_id csv_test \
+  --model $model_name \
+  --features MS \
+  --seq_len 60 \
+  --label_len 30 \
+  --pred_len 30 \
+  --enc_in 10 --dec_in 10 --c_out 10 \
+  --interval_mult 2.0 \
+  --itr 1
+
+# ---------- SQLiteFolder ----------
+python -u run.py \
+  --task_name long_term_forecast \
+  --is_training 0 \
+  --data sqlitefolder \
+  --root_path /path/to/db/folder/ \
+  --table_name your_table \
+  --state all \
+  --model_id db_test \
+  --model $model_name \
+  --features MS \
+  --seq_len 60 \
+  --label_len 30 \
+  --pred_len 30 \
+  --enc_in 10 --dec_in 10 --c_out 10 \
+  --interval_mult 2.0 \
+  --itr 1
+


### PR DESCRIPTION
## Summary
- implement `TimesNetRange_Hybrid` combining GRU with TimesNet blocks for fast interval prediction
- expose new model in `models/__init__.py`
- add comparison script for csvfolder and sqlitefolder loaders
- document new model usage in README

## Testing
- `python -m py_compile models/TimesNetRange_Hybrid.py`


------
https://chatgpt.com/codex/tasks/task_e_68807fcc07208323bf65b3bf72cebe5e