### PR TITLE
Add TimesNetRange_Mamba model

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ python run.py --task_name long_term_forecast \
   --state_condition "rpm >= 10"
 ```
 
+For the Mamba-enhanced variant:
+
+```
+python run.py --task_name long_term_forecast \
+  --is_training 1 --model TimesNetRange_Mamba --data csvfolder \
+  --root_path /path/to/csv_folder --target value --seq_len 96 \
+  --label_len 48 --pred_len 96 --state running \
+  --state_condition "rpm >= 10"
+```
+
 To load a folder of SQLite databases, use the `sqlitefolder` dataset via
 `Dataset_SQLiteFolder`. Provide the table name with `--table_name`. Databases
 must contain a `timestamp` column and consistent feature columns across files.
@@ -129,6 +139,16 @@ Example command:
 ```
 python run.py --task_name long_term_forecast \
   --is_training 1 --model TimesNetRange --data sqlitefolder \
+  --root_path /path/to/db_folder --table_name signals --target value \
+  --seq_len 96 --label_len 48 --pred_len 96 --state running \
+  --state_condition "rpm >= 10"
+```
+
+Using TimesNetRange_Mamba instead:
+
+```
+python run.py --task_name long_term_forecast \
+  --is_training 1 --model TimesNetRange_Mamba --data sqlitefolder \
   --root_path /path/to/db_folder --table_name signals --target value \
   --seq_len 96 --label_len 48 --pred_len 96 --state running \
   --state_condition "rpm >= 10"

--- a/exp/exp_basic.py
+++ b/exp/exp_basic.py
@@ -3,7 +3,7 @@ import torch
 from models import Autoformer, Transformer, TimesNet, Nonstationary_Transformer, DLinear, FEDformer, \
     Informer, LightTS, Reformer, ETSformer, Pyraformer, PatchTST, MICN, Crossformer, FiLM, iTransformer, \
     Koopa, TiDE, FreTS, TimeMixer, TSMixer, SegRNN, MambaSimple, TemporalFusionTransformer, SCINet, PAttn, TimeXer, \
-    WPMixer, MultiPatchFormer, TimesNetRange
+    WPMixer, MultiPatchFormer, TimesNetRange, TimesNetRange_Mamba
 
 
 class Exp_Basic(object):
@@ -39,7 +39,8 @@ class Exp_Basic(object):
             'TimeXer': TimeXer,
             'WPMixer': WPMixer,
             'MultiPatchFormer': MultiPatchFormer,
-            'TimesNetRange': TimesNetRange
+            'TimesNetRange': TimesNetRange,
+            'TimesNetRange_Mamba': TimesNetRange_Mamba
         }
         if args.model == 'Mamba':
             print('Please make sure you have successfully installed mamba_ssm')

--- a/models/TimesNetRange_Mamba.py
+++ b/models/TimesNetRange_Mamba.py
@@ -1,0 +1,117 @@
+import math
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from layers.Embed import DataEmbedding
+from layers.Autoformer_EncDec import series_decomp
+from layers.Conv_Blocks import Inception_Block_V2
+from models.MambaSimple import ResidualBlock
+
+
+def FFT_for_Period(x, k=2):
+    xf = torch.fft.rfft(x, dim=1)
+    frequency_list = abs(xf).mean(0).mean(-1)
+    frequency_list[0] = 0
+    _, top_list = torch.topk(frequency_list, k)
+    top_list = top_list.detach().cpu().numpy()
+    period = x.shape[1] // top_list
+    return period, abs(xf).mean(-1)[:, top_list]
+
+
+class DLinearBlock(nn.Module):
+    """Lightweight DLinear block for baseline forecasting."""
+    def __init__(self, configs):
+        super().__init__()
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.decomp = series_decomp(configs.moving_avg)
+        self.linear_season = nn.Linear(self.seq_len, self.pred_len)
+        self.linear_trend = nn.Linear(self.seq_len, self.pred_len)
+        self.linear_season.weight = nn.Parameter((1 / self.seq_len) * torch.ones([self.pred_len, self.seq_len]))
+        self.linear_trend.weight = nn.Parameter((1 / self.seq_len) * torch.ones([self.pred_len, self.seq_len]))
+
+    def forward(self, x):
+        season, trend = self.decomp(x)
+        season_out = self.linear_season(season.permute(0, 2, 1))
+        trend_out = self.linear_trend(trend.permute(0, 2, 1))
+        out = season_out + trend_out
+        return out.permute(0, 2, 1)
+
+
+class TimesBlockLite(nn.Module):
+    """A lightweight TimesBlock for fast inference."""
+    def __init__(self, configs):
+        super().__init__()
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.k = max(1, configs.top_k // 2)
+        kernel_num = max(2, configs.num_kernels // 2)
+        self.conv = nn.Sequential(
+            Inception_Block_V2(configs.d_model, configs.d_ff, num_kernels=kernel_num),
+            nn.GELU(),
+            Inception_Block_V2(configs.d_ff, configs.d_model, num_kernels=kernel_num),
+        )
+
+    def forward(self, x):
+        B, T, N = x.size()
+        period_list, period_weight = FFT_for_Period(x, self.k)
+        res = []
+        for i in range(self.k):
+            period = period_list[i]
+            if (self.seq_len + self.pred_len) % period != 0:
+                length = ((self.seq_len + self.pred_len) // period + 1) * period
+                padding = torch.zeros([x.shape[0], length - (self.seq_len + self.pred_len), x.shape[2]], device=x.device)
+                out = torch.cat([x, padding], dim=1)
+            else:
+                length = self.seq_len + self.pred_len
+                out = x
+            out = out.reshape(B, length // period, period, N).permute(0, 3, 1, 2).contiguous()
+            out = self.conv(out)
+            out = out.permute(0, 2, 3, 1).reshape(B, -1, N)
+            res.append(out[:, :self.seq_len + self.pred_len, :])
+        res = torch.stack(res, dim=-1)
+        period_weight = F.softmax(period_weight, dim=1)
+        period_weight = period_weight.unsqueeze(1).unsqueeze(1).repeat(1, T, N, 1)
+        res = torch.sum(res * period_weight, -1)
+        return res + x
+
+
+class Model(nn.Module):
+    """TimesNetRange enhanced with a lightweight Mamba block."""
+    def __init__(self, configs):
+        super().__init__()
+        self.configs = configs
+        self.task_name = configs.task_name
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+        self.interval_mult = getattr(configs, 'interval_mult', 2.0)
+        self.m_layers = getattr(configs, 'm_layers', 1)
+        self.d_inner = configs.d_model * configs.expand
+        self.dt_rank = math.ceil(configs.d_model / 16)
+
+        self.baseline = DLinearBlock(configs)
+        self.enc_embedding = DataEmbedding(configs.enc_in, configs.d_model, configs.embed, configs.freq, configs.dropout)
+        self.times_layers = nn.ModuleList([TimesBlockLite(configs) for _ in range(configs.e_layers)])
+        self.mamba_layers = nn.ModuleList([ResidualBlock(configs, self.d_inner, self.dt_rank) for _ in range(self.m_layers)])
+        self.layer_norm = nn.LayerNorm(configs.d_model)
+        self.mean_projection = nn.Linear(configs.d_model, configs.c_out, bias=True)
+        self.var_projection = nn.Linear(configs.d_model, configs.c_out, bias=True)
+
+    def forward(self, x_enc, x_mark_enc, x_dec=None, x_mark_dec=None):
+        baseline = self.baseline(x_enc)
+        enc_out = self.enc_embedding(x_enc, x_mark_enc)
+        for block in self.times_layers:
+            enc_out = self.layer_norm(block(enc_out))
+        for block in self.mamba_layers:
+            enc_out = block(enc_out)
+        mean_residual = self.mean_projection(enc_out)
+        log_var = self.var_projection(enc_out)
+        mean = baseline + mean_residual
+        std = torch.sqrt(F.softplus(log_var) + 1e-6)
+        lower = mean - self.interval_mult * std
+        upper = mean + self.interval_mult * std
+
+        if self.task_name in ['long_term_forecast', 'short_term_forecast']:
+            return mean[:, -self.pred_len:, :], lower[:, -self.pred_len:, :], upper[:, -self.pred_len:, :]
+        else:
+            return mean[:, -self.pred_len:, :]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,2 @@
 from .TimesNetRange import Model as TimesNetRange
+from .TimesNetRange_Mamba import Model as TimesNetRange_Mamba


### PR DESCRIPTION
## Summary
- add a Mamba-enhanced variant `TimesNetRange_Mamba`
- register the new model in `__init__` and `exp_basic`
- document usage examples for csv and sqlite folders

## Testing
- `python -m py_compile models/TimesNetRange_Mamba.py`
- `python -m py_compile models/__init__.py exp/exp_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_68807fcc07208323bf65b3bf72cebe5e