### PR TITLE
Fix dataset and model imports

### DIFF
--- a/data_provider/data_factory.py
+++ b/data_provider/data_factory.py
@@ -72,19 +72,28 @@ def data_provider(args, flag):
                                  'state_condition': args.state_condition})
         if args.data == 'sqlitefolder':
             extra_kwargs.update({'table_name': args.table_name})
-        data_set = Data(
-            args = args,
-            root_path=args.root_path,
-            data_path=args.data_path,
-            flag=flag,
-            size=[args.seq_len, args.label_len, args.pred_len],
-            features=args.features,
-            target=args.target,
-            timeenc=timeenc,
-            freq=freq,
-            seasonal_patterns=args.seasonal_patterns,
+
+        data_kwargs = {
+            'args': args,
+            'root_path': args.root_path,
+            'flag': flag,
+            'size': [args.seq_len, args.label_len, args.pred_len],
+            'features': args.features,
+            'target': args.target,
+            'timeenc': timeenc,
+            'freq': freq,
+            'seasonal_patterns': args.seasonal_patterns,
             **extra_kwargs
-        )
+        }
+        # ``csvfolder`` and ``sqlitefolder`` datasets load all files from the
+        # root path and therefore do not expect ``data_path``.  Passing it
+        # triggers ``TypeError: __init__() got an unexpected keyword
+        # argument 'data_path'``.  Only include ``data_path`` for datasets that
+        # require a specific file.
+        if args.data not in ['csvfolder', 'sqlitefolder']:
+            data_kwargs['data_path'] = args.data_path
+
+        data_set = Data(**data_kwargs)
         print(flag, len(data_set))
         data_loader = DataLoader(
             data_set,

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,2 +1,17 @@
-from .TimesNetRange import Model as TimesNetRange
-from .TimesNetRange_Mamba import Model as TimesNetRange_Mamba
+"""Model package initializer.
+
+The experiment classes expect each entry in ``Exp_Basic.model_dict`` to be a
+module that exposes a ``Model`` attribute.  Previously ``TimesNetRange`` and
+``TimesNetRange_Mamba`` were imported as the ``Model`` class directly which
+meant ``self.model_dict['TimesNetRange'].Model`` raised an ``AttributeError``.
+
+To align with the expectation, import the submodules themselves so that the
+``Model`` class can be accessed via ``module.Model``.
+"""
+
+# Import submodules rather than the classes so callers can access
+# ``TimesNetRange.Model`` or ``TimesNetRange_Mamba.Model``.
+from . import TimesNetRange
+from . import TimesNetRange_Mamba
+
+__all__ = ["TimesNetRange", "TimesNetRange_Mamba"]


### PR DESCRIPTION
## Summary
- Import `TimesNetRange` modules instead of classes to satisfy experiment loader
- Only pass `data_path` to datasets that accept it

## Testing
- `python -m py_compile models/__init__.py data_provider/data_factory.py`
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6891ccada7f48323b30aead31b33af5c