### PR TITLE
Fix dataset seasonal_patterns parameter handling

### DIFF
--- a/data_provider/data_loader.py
+++ b/data_provider/data_loader.py
@@ -323,7 +323,7 @@ class Dataset_CSVFolder(Dataset):
 
     def __init__(self, args, root_path, flag='train', size=None,
                  features='S', target='value', scale=True, timeenc=0, freq='h',
-                 state='all', state_column='state', speed_column='speed',
+                 seasonal_patterns=None, state='all', state_column='state', speed_column='speed',
                  speed_threshold=0.1, state_condition=None):
         self.args = args
         if size is None:
@@ -474,7 +474,7 @@ class Dataset_SQLiteFolder(Dataset):
 
     def __init__(self, args, root_path, flag='train', size=None,
                  features='S', target='value', scale=True, timeenc=0, freq='h',
-                 table_name=None, state='all', state_column='state',
+                 seasonal_patterns=None, table_name=None, state='all', state_column='state',
                  speed_column='speed', speed_threshold=0.1,
                  state_condition=None):
         if table_name is None:


### PR DESCRIPTION
## Summary
- Allow `Dataset_CSVFolder` to accept an optional `seasonal_patterns` argument
- Allow `Dataset_SQLiteFolder` to accept an optional `seasonal_patterns` argument

## Testing
- `python run.py --task_name long_term_forecast --is_training 1 --model_id demo_test --model TimesNet --data csvfolder --root_path test_data --target value --seq_len 96 --label_len 48 --pred_len 96 --features S --enc_in 1 --dec_in 1 --c_out 1 --train_epochs 1 --num_workers 0 --itr 1` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install pandas==1.5.3 scikit-learn==1.2.2 numpy==1.23.5 torch==1.7.1 --quiet` *(fails: Could not find a version that satisfies the requirement pandas==1.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_6892a79993fc83239be8dfb6fd83046c