### PR TITLE
Handle 2D inputs during test visualization

### DIFF
--- a/exp/exp_long_term_forecasting.py
+++ b/exp/exp_long_term_forecasting.py
@@ -271,8 +271,12 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                     if test_data.scale and self.args.inverse:
                         shape = input.shape
                         input = test_data.inverse_transform(input.reshape(shape[0] * shape[1], -1)).reshape(shape)
-                    gt = np.concatenate((input[0, :, -1], true[0, :, -1]), axis=0)
-                    pd = np.concatenate((input[0, :, -1], pred[0, :, -1]), axis=0)
+                    if input.ndim == 3 and true.ndim == 3 and pred.ndim == 3:
+                        gt = np.concatenate((input[0, :, -1], true[0, :, -1]), axis=0)
+                        pd = np.concatenate((input[0, :, -1], pred[0, :, -1]), axis=0)
+                    else:
+                        gt = np.concatenate((input[:, -1], true[:, -1]), axis=0)
+                        pd = np.concatenate((input[:, -1], pred[:, -1]), axis=0)
                     visual(gt, pd, os.path.join(folder_path, str(i) + '.pdf'))
 
         preds = np.concatenate(preds, axis=0)


### PR DESCRIPTION
## Summary
- Avoid IndexError in long-term forecasting tests by handling 2D arrays during result visualization

## Testing
- `python -m py_compile exp/exp_long_term_forecasting.py`
- `python - <<'PY'
import numpy as np

def snippet(input, true, pred):
    if input.ndim == 3 and true.ndim == 3 and pred.ndim == 3:
        gt = np.concatenate((input[0, :, -1], true[0, :, -1]), axis=0)
        pd = np.concatenate((input[0, :, -1], pred[0, :, -1]), axis=0)
    else:
        gt = np.concatenate((input[:, -1], true[:, -1]), axis=0)
        pd = np.concatenate((input[:, -1], pred[:, -1]), axis=0)
    return gt.shape, pd.shape

# test 3D
input = np.random.rand(1, 10, 2)
true = np.random.rand(1, 5, 2)

pred = np.random.rand(1, 5, 2)
print('3D', snippet(input, true, pred))

# test 2D
input2 = np.random.rand(10, 2)
true2 = np.random.rand(5, 2)
pred2 = np.random.rand(5, 2)
print('2D', snippet(input2, true2, pred2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6893f99afbe083238c563f1f85ea3b1a