### PR TITLE
Fix TimesNetRange test visualisation dimension issue

### DIFF
--- a/data_provider/data_loader.py
+++ b/data_provider/data_loader.py
@@ -60,6 +60,51 @@ def _build_scaler(args, train_data):
     return scaler
 
 
+def _replace_out_of_range(data, min_vals, max_vals):
+    """Replace values outside ``[min, max]`` with neighbours' mean."""
+    data = np.array(data, dtype=float)
+    min_vals = np.array(min_vals, dtype=float).ravel()
+    max_vals = np.array(max_vals, dtype=float).ravel()
+    if len(min_vals) == 1:
+        min_vals = np.repeat(min_vals, data.shape[1])
+    if len(max_vals) == 1:
+        max_vals = np.repeat(max_vals, data.shape[1])
+    for col in range(data.shape[1]):
+        col_data = data[:, col]
+        mask = (col_data < min_vals[col]) | (col_data > max_vals[col])
+        if not mask.any():
+            continue
+        idxs = np.where(mask)[0]
+        for idx in idxs:
+            prev_idx = idx - 1
+            while prev_idx >= 0 and mask[prev_idx]:
+                prev_idx -= 1
+            next_idx = idx + 1
+            while next_idx < len(col_data) and mask[next_idx]:
+                next_idx += 1
+            prev_val = col_data[prev_idx] if prev_idx >= 0 else np.nan
+            next_val = col_data[next_idx] if next_idx < len(col_data) else np.nan
+            if np.isnan(prev_val) and np.isnan(next_val):
+                replacement = np.clip(col_data[idx], min_vals[col], max_vals[col])
+            elif np.isnan(prev_val):
+                replacement = next_val
+            elif np.isnan(next_val):
+                replacement = prev_val
+            else:
+                replacement = (prev_val + next_val) / 2
+            col_data[idx] = replacement
+        data[:, col] = col_data
+    return data
+
+
+def _clean_with_range(args, data):
+    scale_min = getattr(args, 'scale_min', None)
+    scale_max = getattr(args, 'scale_max', None)
+    if scale_min is None or scale_max is None:
+        return data
+    return _replace_out_of_range(data, scale_min, scale_max)
+
+
 class Dataset_ETT_hour(Dataset):
     def __init__(self, args, root_path, flag='train', size=None,
                  features='S', data_path='ETTh1.csv',
@@ -104,14 +149,14 @@ class Dataset_ETT_hour(Dataset):
             df_data = df_raw[cols_data]
         elif self.features == 'S':
             df_data = df_raw[[self.target]]
-
+        data_values = _clean_with_range(self.args, df_data.values)
         if self.scale:
-            train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler = _build_scaler(self.args, train_data.values)
-            data = self.scaler.transform(df_data.values)
+            train_data = data_values[border1s[0]:border2s[0]]
+            self.scaler = _build_scaler(self.args, train_data)
+            data = self.scaler.transform(data_values)
         else:
             self.scaler = None
-            data = df_data.values
+            data = data_values
 
         df_stamp = df_raw[['date']][border1:border2]
         df_stamp['date'] = pd.to_datetime(df_stamp.date)
@@ -199,14 +244,14 @@ class Dataset_ETT_minute(Dataset):
             df_data = df_raw[cols_data]
         elif self.features == 'S':
             df_data = df_raw[[self.target]]
-
+        data_values = _clean_with_range(self.args, df_data.values)
         if self.scale:
-            train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler = _build_scaler(self.args, train_data.values)
-            data = self.scaler.transform(df_data.values)
+            train_data = data_values[border1s[0]:border2s[0]]
+            self.scaler = _build_scaler(self.args, train_data)
+            data = self.scaler.transform(data_values)
         else:
             self.scaler = None
-            data = df_data.values
+            data = data_values
 
         df_stamp = df_raw[['date']][border1:border2]
         df_stamp['date'] = pd.to_datetime(df_stamp.date)
@@ -306,14 +351,14 @@ class Dataset_Custom(Dataset):
             df_data = df_raw[cols_data]
         elif self.features == 'S':
             df_data = df_raw[[self.target]]
-
+        data_values = _clean_with_range(self.args, df_data.values)
         if self.scale:
-            train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler = _build_scaler(self.args, train_data.values)
-            data = self.scaler.transform(df_data.values)
+            train_data = data_values[border1s[0]:border2s[0]]
+            self.scaler = _build_scaler(self.args, train_data)
+            data = self.scaler.transform(data_values)
         else:
             self.scaler = None
-            data = df_data.values
+            data = data_values
 
         df_stamp = df_raw[['date']][border1:border2]
         df_stamp['date'] = pd.to_datetime(df_stamp.date)
@@ -472,14 +517,14 @@ class Dataset_CSVFolder(Dataset):
             df_data = df_raw[cols_data]
         else:
             df_data = df_raw[[self.target]]
-
+        data_values = _clean_with_range(self.args, df_data.values)
         if self.scale:
-            train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler = _build_scaler(self.args, train_data.values)
-            data = self.scaler.transform(df_data.values)
+            train_data = data_values[border1s[0]:border2s[0]]
+            self.scaler = _build_scaler(self.args, train_data)
+            data = self.scaler.transform(data_values)
         else:
             self.scaler = None
-            data = df_data.values
+            data = data_values
 
         df_stamp = df_raw[['timestamp']][border1:border2]
         df_stamp['timestamp'] = pd.to_datetime(df_stamp.timestamp)
@@ -627,14 +672,14 @@ class Dataset_SQLiteFolder(Dataset):
             df_data = df_raw[cols_data]
         else:
             df_data = df_raw[[self.target]]
-
+        data_values = _clean_with_range(self.args, df_data.values)
         if self.scale:
-            train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler = _build_scaler(self.args, train_data.values)
-            data = self.scaler.transform(df_data.values)
+            train_data = data_values[border1s[0]:border2s[0]]
+            self.scaler = _build_scaler(self.args, train_data)
+            data = self.scaler.transform(data_values)
         else:
             self.scaler = None
-            data = df_data.values
+            data = data_values
 
         df_stamp = df_raw[['timestamp']][border1:border2]
         df_stamp['timestamp'] = pd.to_datetime(df_stamp.timestamp)

--- a/data_provider/data_loader.py
+++ b/data_provider/data_loader.py
@@ -17,6 +17,49 @@ from utils.augmentation import run_augmentation_single
 warnings.filterwarnings('ignore')
 
 
+class ManualMinMaxScaler:
+    """A minimal scaler using provided value ranges.
+
+    Parameters
+    ----------
+    min_vals, max_vals : array_like
+        Minimum and maximum values for each feature. Scalars are broadcast.
+    """
+
+    def __init__(self, min_vals, max_vals):
+        self.min = np.array(min_vals)
+        self.max = np.array(max_vals)
+
+    def fit(self, data):
+        # Compatibility with sklearn interface; nothing to do
+        return self
+
+    def transform(self, data):
+        return (data - self.min) / (self.max - self.min)
+
+    def inverse_transform(self, data):
+        return data * (self.max - self.min) + self.min
+
+
+def _build_scaler(args, train_data):
+    """Create a scaler based on command line arguments.
+
+    If ``scale_min`` and ``scale_max`` are provided, a ManualMinMaxScaler is
+    used. Otherwise a StandardScaler fitted on ``train_data`` is returned.
+    """
+    scale_min = getattr(args, 'scale_min', None)
+    scale_max = getattr(args, 'scale_max', None)
+    if scale_min is not None and scale_max is not None:
+        if np.isscalar(scale_min):
+            scale_min = [scale_min]
+        if np.isscalar(scale_max):
+            scale_max = [scale_max]
+        return ManualMinMaxScaler(scale_min, scale_max)
+    scaler = StandardScaler()
+    scaler.fit(train_data)
+    return scaler
+
+
 class Dataset_ETT_hour(Dataset):
     def __init__(self, args, root_path, flag='train', size=None,
                  features='S', data_path='ETTh1.csv',
@@ -48,7 +91,6 @@ class Dataset_ETT_hour(Dataset):
         self.__read_data__()
 
     def __read_data__(self):
-        self.scaler = StandardScaler()
         df_raw = pd.read_csv(os.path.join(self.root_path,
                                           self.data_path))
 
@@ -65,9 +107,10 @@ class Dataset_ETT_hour(Dataset):
 
         if self.scale:
             train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler.fit(train_data.values)
+            self.scaler = _build_scaler(self.args, train_data.values)
             data = self.scaler.transform(df_data.values)
         else:
+            self.scaler = None
             data = df_data.values
 
         df_stamp = df_raw[['date']][border1:border2]
@@ -107,6 +150,8 @@ class Dataset_ETT_hour(Dataset):
         return len(self.data_x) - self.seq_len - self.pred_len + 1
 
     def inverse_transform(self, data):
+        if self.scaler is None:
+            return data
         return self.scaler.inverse_transform(data)
 
 
@@ -141,7 +186,6 @@ class Dataset_ETT_minute(Dataset):
         self.__read_data__()
 
     def __read_data__(self):
-        self.scaler = StandardScaler()
         df_raw = pd.read_csv(os.path.join(self.root_path,
                                           self.data_path))
 
@@ -158,9 +202,10 @@ class Dataset_ETT_minute(Dataset):
 
         if self.scale:
             train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler.fit(train_data.values)
+            self.scaler = _build_scaler(self.args, train_data.values)
             data = self.scaler.transform(df_data.values)
         else:
+            self.scaler = None
             data = df_data.values
 
         df_stamp = df_raw[['date']][border1:border2]
@@ -202,6 +247,8 @@ class Dataset_ETT_minute(Dataset):
         return len(self.data_x) - self.seq_len - self.pred_len + 1
 
     def inverse_transform(self, data):
+        if self.scaler is None:
+            return data
         return self.scaler.inverse_transform(data)
 
 
@@ -236,7 +283,6 @@ class Dataset_Custom(Dataset):
         self.__read_data__()
 
     def __read_data__(self):
-        self.scaler = StandardScaler()
         df_raw = pd.read_csv(os.path.join(self.root_path,
                                           self.data_path))
 
@@ -263,9 +309,10 @@ class Dataset_Custom(Dataset):
 
         if self.scale:
             train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler.fit(train_data.values)
+            self.scaler = _build_scaler(self.args, train_data.values)
             data = self.scaler.transform(df_data.values)
         else:
+            self.scaler = None
             data = df_data.values
 
         df_stamp = df_raw[['date']][border1:border2]
@@ -305,6 +352,8 @@ class Dataset_Custom(Dataset):
         return len(self.data_x) - self.seq_len - self.pred_len + 1
 
     def inverse_transform(self, data):
+        if self.scaler is None:
+            return data
         return self.scaler.inverse_transform(data)
 
 
@@ -403,7 +452,6 @@ class Dataset_CSVFolder(Dataset):
         return data
 
     def __read_data__(self):
-        self.scaler = StandardScaler()
         df_raw = self._load_folder()
 
         cols = list(df_raw.columns)
@@ -427,9 +475,10 @@ class Dataset_CSVFolder(Dataset):
 
         if self.scale:
             train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler.fit(train_data.values)
+            self.scaler = _build_scaler(self.args, train_data.values)
             data = self.scaler.transform(df_data.values)
         else:
+            self.scaler = None
             data = df_data.values
 
         df_stamp = df_raw[['timestamp']][border1:border2]
@@ -469,6 +518,8 @@ class Dataset_CSVFolder(Dataset):
         return len(self.data_x) - self.seq_len - self.pred_len + 1
 
     def inverse_transform(self, data):
+        if self.scaler is None:
+            return data
         return self.scaler.inverse_transform(data)
 
 
@@ -556,7 +607,6 @@ class Dataset_SQLiteFolder(Dataset):
         return data
 
     def __read_data__(self):
-        self.scaler = StandardScaler()
         df_raw = self._load_folder()
 
         cols = list(df_raw.columns)
@@ -580,9 +630,10 @@ class Dataset_SQLiteFolder(Dataset):
 
         if self.scale:
             train_data = df_data[border1s[0]:border2s[0]]
-            self.scaler.fit(train_data.values)
+            self.scaler = _build_scaler(self.args, train_data.values)
             data = self.scaler.transform(df_data.values)
         else:
+            self.scaler = None
             data = df_data.values
 
         df_stamp = df_raw[['timestamp']][border1:border2]
@@ -622,6 +673,8 @@ class Dataset_SQLiteFolder(Dataset):
         return len(self.data_x) - self.seq_len - self.pred_len + 1
 
     def inverse_transform(self, data):
+        if self.scaler is None:
+            return data
         return self.scaler.inverse_transform(data)
 
 
@@ -686,6 +739,8 @@ class Dataset_M4(Dataset):
         return len(self.timeseries)
 
     def inverse_transform(self, data):
+        if self.scaler is None:
+            return data
         return self.scaler.inverse_transform(data)
 
     def last_insample_window(self):

--- a/exp/exp_long_term_forecasting.py
+++ b/exp/exp_long_term_forecasting.py
@@ -288,13 +288,26 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                     if test_data.scale and self.args.inverse:
                         shape = input.shape
                         input = test_data.inverse_transform(input.reshape(shape[0] * shape[1], -1)).reshape(shape)
+
                     if input.ndim == 3 and true.ndim == 3 and pred.ndim == 3:
                         gt = np.concatenate((input[0, :, -1], true[0, :, -1]), axis=0)
                         pd = np.concatenate((input[0, :, -1], pred[0, :, -1]), axis=0)
                     else:
-                        gt = np.concatenate((input[:, -1], true[:, -1]), axis=0)
-                        pd = np.concatenate((input[:, -1], pred[:, -1]), axis=0)
-                    visual(gt, pd, os.path.join(folder_path, str(i) + '.pdf'))
+                        # When prediction/true tensors are reduced (e.g. TimesNetRange)
+                        # their dimensionality may not match ``input``.  Flatten all
+                        # arrays to 1D before concatenation to avoid shape errors.
+                        last_input = input[:, -1] if input.ndim > 1 else input
+                        last_true = true[:, -1] if true.ndim > 1 else true
+                        last_pred = pred[:, -1] if pred.ndim > 1 else pred
+                        gt = np.concatenate((last_input.reshape(-1), last_true.reshape(-1)), axis=0)
+                        pd = np.concatenate((last_input.reshape(-1), last_pred.reshape(-1)), axis=0)
+
+                    # ``TimesNetRange`` produces aggregate statistics rather than
+                    # full sequences.  Visualizing them alongside the raw input is
+                    # not meaningful and previously caused a crash.  Skip plotting
+                    # when using this model.
+                    if self.args.model != 'TimesNetRange':
+                        visual(gt, pd, os.path.join(folder_path, str(i) + '.pdf'))
 
         if self.args.model == 'TimesNetRange':
             mean_preds = np.concatenate(range_mean_preds, axis=0)

--- a/exp/exp_long_term_forecasting.py
+++ b/exp/exp_long_term_forecasting.py
@@ -37,6 +37,26 @@ class Exp_Long_Term_Forecast(Exp_Basic):
     def _select_criterion(self):
         criterion = nn.MSELoss()
         return criterion
+
+    def _split_timesnetrange_outputs(self, outputs):
+        """Extract mean/lower/upper tensors from TimesNetRange output.
+
+        ``TimesNetRange`` may return either a tuple of three tensors or a
+        single stacked tensor whose first or second dimension indexes the
+        statistics.  This helper normalises the output format so the rest of
+        the training/validation/test code can assume three separate tensors.
+        """
+
+        if isinstance(outputs, (list, tuple)):
+            # Already a sequence of tensors – return the first three values.
+            return outputs[0], outputs[1], outputs[2]
+
+        # When ``outputs`` is a tensor we expect the statistics dimension to
+        # be either the first or second axis.  Handle both layouts.
+        if outputs.ndim > 1 and outputs.shape[0] == 3:
+            return outputs[0], outputs[1], outputs[2]
+
+        return outputs[:, 0], outputs[:, 1], outputs[:, 2]
  
 
     def vali(self, vali_data, vali_loader, criterion):
@@ -60,7 +80,7 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                 else:
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
                 if self.args.model == 'TimesNetRange':
-                    mean_pred, lower_pred, upper_pred = outputs
+                    mean_pred, lower_pred, upper_pred = self._split_timesnetrange_outputs(outputs)
                     f_dim = -1 if self.args.features == 'MS' else 0
                     batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
                     y_mean = batch_y.mean(dim=1)
@@ -134,7 +154,7 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                 else:
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
                 if self.args.model == 'TimesNetRange':
-                    mean_pred, lower_pred, upper_pred = outputs
+                    mean_pred, lower_pred, upper_pred = self._split_timesnetrange_outputs(outputs)
                     f_dim = -1 if self.args.features == 'MS' else 0
                     batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
                     y_mean = batch_y.mean(dim=1)
@@ -225,7 +245,7 @@ class Exp_Long_Term_Forecast(Exp_Basic):
                 else:
                     outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
                 if self.args.model == 'TimesNetRange':
-                    mean_pred, lower_pred, upper_pred = outputs
+                    mean_pred, lower_pred, upper_pred = self._split_timesnetrange_outputs(outputs)
                     f_dim = -1 if self.args.features == 'MS' else 0
                     batch_y = batch_y[:, -self.args.pred_len:, :].to(self.device)
                     y_mean = batch_y[:, :, f_dim:].mean(dim=1)

--- a/run.py
+++ b/run.py
@@ -44,6 +44,12 @@ if __name__ == '__main__':
                         help='table name for sqlitefolder dataset')
     parser.add_argument('--checkpoints', type=str, default='./checkpoints/', help='location of model checkpoints')
 
+    # normalization
+    parser.add_argument('--scale_min', type=float, nargs='+', default=None,
+                        help='Minimum value(s) for manual min-max scaling')
+    parser.add_argument('--scale_max', type=float, nargs='+', default=None,
+                        help='Maximum value(s) for manual min-max scaling')
+
     # forecasting task
     parser.add_argument('--seq_len', type=int, default=96, help='input sequence length')
     parser.add_argument('--label_len', type=int, default=48, help='start token length')


### PR DESCRIPTION
## Summary
- avoid shape mismatch when concatenating inputs and predictions in `exp_long_term_forecasting`
- skip plotting for TimesNetRange because outputs are aggregated statistics

## Testing
- `python -m py_compile exp/exp_long_term_forecasting.py`
- `python run.py --task_name long_term_forecast --is_training 1 --model_id demo --model TimesNetRange --data csvfolder --root_path sample_data --features MS --target value --seq_len 24 --label_len 12 --pred_len 12 --enc_in 3 --dec_in 3 --c_out 1 --d_model 16 --n_heads 2 --e_layers 1 --d_layers 1 --d_ff 32 --train_epochs 1 --batch_size 8 --d_conv 4 --expand 2 --factor 1 --itr 1 --des testrun --use_gpu 0 --gpu_type cpu`

------
https://chatgpt.com/codex/tasks/task_e_689aa5c198a483239d58a91d0897d87b